### PR TITLE
feat: read JWT secret from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ interface.
 
 ## Running
 1. Install dependencies: `npm install`
-2. Start the server: `npm start`
-3. Open `http://localhost:3000/` in your browser.
+2. Set a JWT secret: `export JWT_SECRET=your-secret` (Windows use `set JWT_SECRET=your-secret`)
+3. Start the server: `npm start`
+4. Open `http://localhost:3000/` in your browser.
    The landing page offers links to register or log in before entering the game.
 
 

--- a/server.js
+++ b/server.js
@@ -75,7 +75,11 @@ const nameRegex = /^[A-Za-z0-9\u4E00-\u9FFF.,•，。_]{1,10}$/;
 const areaNameRegex = /^[A-Za-z0-9\u4E00-\u9FFF]{3,11}$/;
 const monsterNameRegex = /^[A-Za-z0-9\u4E00-\u9FFF]{3,11}$/;
 
-const SECRET = 'dev-secret';
+const SECRET = process.env.JWT_SECRET;
+if (!SECRET) {
+  console.error('JWT_SECRET environment variable is required');
+  process.exit(1);
+}
 
 const captchas = new Map();
 

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -1,3 +1,4 @@
+process.env.JWT_SECRET = 'test-secret';
 const request = require('supertest');
 const path = require('path');
 const fs = require('fs').promises;

--- a/tests/stats.test.js
+++ b/tests/stats.test.js
@@ -1,3 +1,4 @@
+process.env.JWT_SECRET = 'test-secret';
 const {
   hpAtLevel,
   attackAtLevel,


### PR DESCRIPTION
## Summary
- read JWT signing key from `JWT_SECRET` environment variable
- document requirement to set `JWT_SECRET`
- adjust tests to define `JWT_SECRET`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfc612c0f0832386e9e3e2df24450e