### PR TITLE
Fix local authentication ergonomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,19 @@ interface.
    - `export JWT_SECRET=your-secret`
    - `export SESSION_TTL_HOURS=24` *(optional, defaults to 24)*
    - `export SESSION_IDLE_TIMEOUT_SEC=600` *(optional, defaults to 600 seconds)*
+   - `export COOKIE_SECURE=true` *(optional; defaults to `true` when `NODE_ENV=production`, otherwise `false`)*
+   - `export DISABLE_CAPTCHA=false` *(optional; set to `true` locally to skip CAPTCHA checks while developing)*
    (Windows use `set` instead of `export`.)
+   You can also place these values in a `.env` file if you use a manager like [direnv](https://direnv.net/) or `dotenv-cli`.
+
+   **Local development example**
+   ```bash
+   NODE_ENV=development
+   COOKIE_SECURE=false
+   DISABLE_CAPTCHA=true
+   DATABASE_URL=postgres://user:pass@localhost:5432/game
+   JWT_SECRET=replace-this-with-a-random-string
+   ```
 3. Start the server: `npm start`
 4. Open `http://localhost:3000/` in your browser.
    The landing page offers links to register or log in before entering the game.

--- a/db.js
+++ b/db.js
@@ -517,16 +517,7 @@ async function createSession(accountId, meta = {}) {
   if (!accountId) throw new Error('accountId required');
   return withTx(async client => {
     const runner = exec(client);
-    await runner.query('DELETE FROM sessions WHERE account_id=$1 AND expires_at <= now()', [accountId]);
-    const { rows } = await runner.query(
-      'SELECT 1 FROM sessions WHERE account_id=$1 AND expires_at > now() LIMIT 1',
-      [accountId]
-    );
-    if (rows.length > 0) {
-      const err = new Error('already logged in');
-      err.code = 'ALREADY_LOGGED_IN';
-      throw err;
-    }
+    await runner.query('DELETE FROM sessions WHERE account_id=$1', [accountId]);
     const sessionId = randomUUID();
     try {
       await runner.query(
@@ -535,11 +526,6 @@ async function createSession(accountId, meta = {}) {
         [sessionId, accountId, Math.max(1, Math.floor(SESSION_TTL_MS)), meta.userAgent || null, meta.ip || null]
       );
     } catch (err) {
-      if (err.code === '23505') {
-        const dup = new Error('already logged in');
-        dup.code = 'ALREADY_LOGGED_IN';
-        throw dup;
-      }
       throw err;
     }
     const expiresAt = new Date(Date.now() + Math.max(1, Math.floor(SESSION_TTL_MS)));

--- a/login.js
+++ b/login.js
@@ -18,17 +18,12 @@ loginBtn.addEventListener('click', async () => {
   if (res.ok) {
     localStorage.setItem('currentUser', username);
     window.location.href = 'index.html';
-  } else {
-    let message = '登入失敗，請再試一次。';
-    if (res.status === 409) {
-      message = '此帳號已在其他地方登入。';
-    } else {
-      const data = await res.json().catch(() => ({}));
-      if (data && data.error === 'invalid credentials') {
-        message = '帳號或密碼錯誤。';
-      }
-    }
-    errorMsg.textContent = message;
-    errorMsg.classList.remove('hidden');
+    return;
   }
+  let message = '登入失敗，請再試一次。';
+  if (res.status === 401) {
+    message = '帳號或密碼錯誤。';
+  }
+  errorMsg.textContent = message;
+  errorMsg.classList.remove('hidden');
 });

--- a/player.js
+++ b/player.js
@@ -14,6 +14,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     handleAuthFailure(data?.error);
     return;
   }
+  if (res.status === 404) {
+    alert('尚未建立角色，請先返回遊戲頁面創角。');
+    window.location.href = 'index.html';
+    return;
+  }
   if (!res.ok) {
     alert('無法載入角色資訊，請稍後再試。');
     return;

--- a/register.js
+++ b/register.js
@@ -1,6 +1,5 @@
 const userRegex = /^[A-Za-z0-9!@#$%^&*]{5,20}$/;
 const passRegex = /^[A-Za-z0-9!@#$%^&*]{8,20}$/;
-let captchaText = '';
 let captchaId = '';
 
 async function drawCaptcha() {
@@ -10,10 +9,9 @@ async function drawCaptcha() {
   const res = await fetch('/api/captcha');
   const data = await res.json();
   captchaId = data.id;
-  captchaText = data.text;
   ctx.font = '24px sans-serif';
   ctx.textBaseline = 'middle';
-  ctx.fillText(captchaText, 10, canvas.height / 2);
+  ctx.fillText(data.text, 10, canvas.height / 2);
 }
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -28,20 +26,40 @@ registerBtn.addEventListener('click', async () => {
   const password = document.getElementById('regPassword').value.trim();
   const captcha = document.getElementById('regCaptcha').value.trim().toUpperCase();
 
-  if (!userRegex.test(username) || !passRegex.test(password) || captcha !== captchaText) {
+  errorMsg.classList.add('hidden');
+  errorMsg.textContent = '';
+
+  if (!userRegex.test(username) || !passRegex.test(password)) {
+    errorMsg.textContent = '帳號或密碼格式不符要求。';
     errorMsg.classList.remove('hidden');
     drawCaptcha();
     return;
   }
+
+  const payload = { username, password };
+  if (captchaId) payload.captchaId = captchaId;
+  if (captcha) payload.captcha = captcha;
+
   const res = await fetch('/api/register', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ username, password, captchaId, captcha })
+    body: JSON.stringify(payload)
   });
   if (res.ok) {
     window.location.href = 'login.html';
-  } else {
-    errorMsg.classList.remove('hidden');
-    drawCaptcha();
+    return;
   }
+
+  const data = await res.json().catch(() => ({}));
+  let message = '註冊失敗，請再試一次。';
+  if (data?.error === 'invalid captcha') {
+    message = '驗證碼錯誤，請再試一次。';
+  } else if (data?.error === 'username-taken') {
+    message = '此帳號已被使用。';
+  } else if (data?.error === 'invalid input') {
+    message = '帳號或密碼格式不符要求。';
+  }
+  errorMsg.textContent = message;
+  errorMsg.classList.remove('hidden');
+  drawCaptcha();
 });

--- a/server.js
+++ b/server.js
@@ -410,8 +410,14 @@ if (!SECRET) {
 
 const captchas = new Map();
 
-const COOKIE_BASE = { httpOnly: true, secure: true, sameSite: 'lax', path: '/' };
+const SECURE_COOKIE =
+  process.env.COOKIE_SECURE != null
+    ? process.env.COOKIE_SECURE === 'true'
+    : process.env.NODE_ENV === 'production';
+
+const COOKIE_BASE = { httpOnly: true, sameSite: 'lax', secure: SECURE_COOKIE, path: '/' };
 const COOKIE_WITH_MAX_AGE = { ...COOKIE_BASE, maxAge: SESSION_TTL_MS };
+const DISABLE_CAPTCHA = process.env.DISABLE_CAPTCHA === 'true';
 const JWT_EXPIRES_IN = '7d';
 const SESSION_IDLE_TIMEOUT_SEC = Math.max(0, Math.floor(SESSION_IDLE_TIMEOUT_MS / 1000));
 
@@ -427,6 +433,10 @@ function parseCookies(req) {
     acc[key] = decodeURIComponent(value || '');
     return acc;
   }, {});
+}
+
+function setAuthCookie(res, token) {
+  res.cookie('jwt', token, COOKIE_WITH_MAX_AGE);
 }
 
 function clearAuthCookie(res) {
@@ -459,7 +469,8 @@ async function auth(req, res, next) {
       payload = jwt.verify(token, SECRET);
     } catch (err) {
       clearAuthCookie(res);
-      return res.status(401).json({ error: 'bad-token' });
+      const code = err?.name === 'TokenExpiredError' ? 'session-expired' : 'bad-token';
+      return res.status(401).json({ error: code });
     }
     const { sub, jti, username } = payload;
     if (!sub || !jti || !username) {
@@ -488,10 +499,24 @@ async function ensureActiveSession(req, res, next) {
       clearAuthCookie(res);
       return res.status(401).json({ error: 'unauthorized' });
     }
+    const now = Date.now();
+    let failureCode = 'unauthorized';
+    if (session?.expires_at) {
+      const expiresAt = new Date(session.expires_at).getTime();
+      if (Number.isFinite(expiresAt) && expiresAt <= now) {
+        failureCode = 'session-expired';
+      }
+    }
+    if (failureCode === 'unauthorized' && session?.last_seen && SESSION_IDLE_TIMEOUT_MS > 0) {
+      const lastSeen = new Date(session.last_seen).getTime();
+      if (Number.isFinite(lastSeen) && lastSeen + SESSION_IDLE_TIMEOUT_MS <= now) {
+        failureCode = 'session-timeout';
+      }
+    }
     const touched = await db.touchSession(session.session_id);
     if (!touched) {
       clearAuthCookie(res);
-      return res.status(401).json({ error: 'unauthorized' });
+      return res.status(401).json({ error: failureCode });
     }
     return next();
   } catch (err) {
@@ -708,11 +733,15 @@ app.post('/api/register', async (req, res) => {
   if (!userRegex.test(username) || !passRegex.test(password)) {
     return res.status(400).json({ error: 'invalid input' });
   }
-  const expected = captchas.get(captchaId);
-  if (!expected || expected !== captcha) {
-    return res.status(400).json({ error: 'invalid captcha' });
+  if (!DISABLE_CAPTCHA) {
+    const expected = captchas.get(captchaId);
+    if (!expected || expected !== captcha) {
+      return res.status(400).json({ error: 'invalid captcha' });
+    }
   }
-  captchas.delete(captchaId);
+  if (captchaId) {
+    captchas.delete(captchaId);
+  }
   try {
     if (await isAnyNameTaken(username)) {
       return res.status(400).json({ error: 'username-taken' });
@@ -768,12 +797,9 @@ app.post('/api/login', async (req, res) => {
       const token = jwt.sign({ sub: account.id, jti: sessionId, username: account.username }, SECRET, {
         expiresIn: JWT_EXPIRES_IN
       });
-      res.cookie('jwt', token, COOKIE_WITH_MAX_AGE);
+      setAuthCookie(res, token);
       return res.status(204).end();
     } catch (err) {
-      if (err && err.code === 'ALREADY_LOGGED_IN') {
-        return res.status(409).json({ error: 'already-logged-in' });
-      }
       console.error('createSession failed', err);
       return res.status(500).json({ error: 'internal error' });
     }
@@ -890,7 +916,7 @@ app.get('/api/character', auth, ensureActiveSession, RATE_LIMITER, async (req, r
       return responseCharacter(character);
     });
     if (!result) {
-      return res.status(404).json({ error: 'not found' });
+      return res.status(404).json({ error: 'character-missing' });
     }
     res.json({
       name: result.name,


### PR DESCRIPTION
## Summary
- allow HTTP development logins by making cookie security configurable and reusing the same options when clearing cookies
- permit captcha-free local registration and improve 401 status codes plus single-session replacement on login
- update client flows and documentation to reflect the new auth behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e171147afc83239072f5e4324f70eb